### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ features.
 ![MCP Protocol](https://img.shields.io/badge/MCP-Compatible-green)
 [![smithery badge](https://smithery.ai/badge/cli-mcp-server)](https://smithery.ai/protocol/cli-mcp-server)
 
+<a href="https://glama.ai/mcp/servers/q89277vzl1"><img width="380" height="200" src="https://glama.ai/mcp/servers/q89277vzl1/badge" /></a>
+
 ---
 
 # Table of Contents


### PR DESCRIPTION
This PR adds a badge for the `cli-mcp-server` server listing in Glama MCP server directory.

https://glama.ai/mcp/servers/q89277vzl1

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.