### PR TITLE
add GET_HELP env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Configure the server using environment variables:
 | `MAX_COMMAND_LENGTH`| Maximum command string length                        | `1024`            |
 | `COMMAND_TIMEOUT`   | Command execution timeout (seconds)                  | `30`              |
 | `ALLOW_SHELL_OPERATORS` | Allow shell operators (&&, \|\|, \|, >, etc.)    | `false`           |
+| `GET_HELP`          | Command to get help (eg: `git --help`, `man ls`)     | `""`              |
 
 Note: Setting `ALLOWED_COMMANDS` or `ALLOWED_FLAGS` to 'all' will allow any command or flag respectively.
 


### PR DESCRIPTION
This adds the ability to pre-populate the output of the help command for the mcp. This probably won't be used for the default shell command values but when wrapping less well known cli tools this can come in handy