### PR TITLE
Non-deterministic command order in "run_command" @mcp.tool description

### DIFF
--- a/src/cli_mcp_server/server.py
+++ b/src/cli_mcp_server/server.py
@@ -427,12 +427,12 @@ async def handle_list_tools() -> list[types.Tool]:
     commands_desc = (
         "all commands"
         if executor.security_config.allow_all_commands
-        else ", ".join(executor.security_config.allowed_commands)
+        else ", ".join(sorted(executor.security_config.allowed_commands))
     )
     flags_desc = (
         "all flags"
         if executor.security_config.allow_all_flags
-        else ", ".join(executor.security_config.allowed_flags)
+        else ", ".join(sorted(executor.security_config.allowed_flags))
     )
 
     return [


### PR DESCRIPTION
The run_command tool description shows "Available commands" in a non-deterministic order because allowed_commands is a set[str] and the code uses ", ".join() without sorting.

This causes the tool schema to appear "changed" between runs even when the configuration is identical, which makes it harder to diff/compare tool schemas across versions.

Interestingly, `show_security_rules()` already uses sorted() but handle_list_tools() does not.
